### PR TITLE
🐛: removed preview image api, which was not working

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,9 +59,9 @@
             <h4>Showcases</h4>
             <p>Websites that was made with SuperBro.</p> 
             <ul> 
-                <li><h6>Mun Firma</h6> <img src="https://cdn.statically.io/screenshot/munfirma.fi" alt=""><br><a href="https://munfirma.fi/" class="button">Website</a></li>
-                <li><h6>Kallion Pesula</h6> <img src="https://cdn.statically.io/screenshot/kallionpesula.com" alt=""><br><a href="https://kallionpesula.com/" class="button">Website</a></li>
-                <li><h6>Sanjiv.info</h6> <img src="https://cdn.statically.io/screenshot/sanjiv.info/" alt=""><br><a href="https://sanjiv.info/" class="button">Website</a></li>
+                <li><h6>Mun Firma</h6> <a href="https://munfirma.fi/" class="button">Website</a></li>
+                <li><h6>Kallion Pesula</h6> <a href="https://kallionpesula.com/" class="button">Website</a></li>
+                <li><h6>Sanjiv.info</h6> <a href="https://sanjiv.info/" class="button">Website</a></li>
             </ul>
             <p>If you made website with <strong>SuperBro</strong>, let me know in <strong>Github</strong>.</p>
         </div>


### PR DESCRIPTION
Looks like the https://statically.io/ site's screenshot api is broken, removed the api from website for now. 